### PR TITLE
Fix absolute import for Python 3

### DIFF
--- a/flask_fillin/__init__.py
+++ b/flask_fillin/__init__.py
@@ -9,4 +9,4 @@
     :license: BSD, see LICENSE for more details.
 """
 
-from wrapper import FormWrapper
+from .wrapper import FormWrapper


### PR DESCRIPTION
Right now this package is broken for Python 3. It'd be great if you could merge this then release a new version on pip. 

Everything else works fine in Python 3 with this change.

Thanks.
